### PR TITLE
Update to support major release v3 and bump to 3.2.1

### DIFF
--- a/overlay/usr/local/etc/rc.d/flaresolverr
+++ b/overlay/usr/local/etc/rc.d/flaresolverr
@@ -1,0 +1,29 @@
+#
+# Author: C. R. Zamana (czamana at gmail dot com)
+#
+# PROVIDE: flaresolverr
+# REQUIRE: networking
+# KEYWORD:
+
+. /etc/rc.subr
+
+name="flaresolverr"
+rcvar="${name}_enable"
+load_rc_config ${name}
+
+: ${flaresolverr_enable:="NO"}
+
+pidfile="/var/run/flaresolverr.pid"
+
+start_precmd="flaresolverr_precmd"
+
+PATH=$PATH:/usr/local/bin
+
+flaresolverr_precmd() {
+        cd /usr/local/share/flaresolverr
+}
+
+command="/usr/sbin/daemon"
+command_args="-P ${pidfile} -S -T flaresolverr /usr/local/bin/python3.9 -u src/flaresolverr.py"
+
+run_rc_command "$1"

--- a/post_install.sh
+++ b/post_install.sh
@@ -1,28 +1,15 @@
 #!/bin/sh
 
-cd /usr/local/share
+cd /usr/local/share || exit
 git clone https://github.com/FlareSolverr/FlareSolverr flaresolverr
-cd flaresolverr
+cd flaresolverr || exit
 
 # Checkout version
-git checkout v3.0.2
+git checkout v3.0.4
 
 pip install -r requirements.txt
 
-patch -p1 << EOF
-diff --git a/src/undetected_chromedriver/_compat.py b/src/undetected_chromedriver/_compat.py
-index 6b2f28a..ad8bccc 100644
---- a/src/undetected_chromedriver/_compat.py
-+++ b/src/undetected_chromedriver/_compat.py
-@@ -155,6 +155,8 @@ class ChromeDriverManager(object):
-         if _platform in ("linux",):
-             _platform += "64"
-             exe_name = exe_name.format("")
-+        if _platform in ("freebsd",):
-+            exe_name = exe_name.format("")
-         if _platform in ("darwin",):
-             _platform = "mac64"
-             exe_name = exe_name.format("")
+patch -V none -p1 << EOF
 diff --git a/src/undetected_chromedriver/patcher.py b/src/undetected_chromedriver/patcher.py
 index c20ead8..4c410e4 100644
 --- a/src/undetected_chromedriver/patcher.py

--- a/post_install.sh
+++ b/post_install.sh
@@ -5,16 +5,16 @@ git clone https://github.com/FlareSolverr/FlareSolverr flaresolverr
 cd flaresolverr || exit
 
 # Checkout version
-git checkout v3.0.4
+git checkout v3.2.1
 
 pip install -r requirements.txt
 
 patch -V none -p1 << EOF
 diff --git a/src/undetected_chromedriver/patcher.py b/src/undetected_chromedriver/patcher.py
-index c20ead8..4c410e4 100644
+index 24da802..159ae8d 100644
 --- a/src/undetected_chromedriver/patcher.py
 +++ b/src/undetected_chromedriver/patcher.py
-@@ -18,7 +18,7 @@ import zipfile
+@@ -17,7 +17,7 @@ import zipfile
 
  logger = logging.getLogger(__name__)
 
@@ -24,10 +24,10 @@ index c20ead8..4c410e4 100644
 
  class Patcher(object):
 diff --git a/src/utils.py b/src/utils.py
-index ceff7ec..dd3aba5 100644
+index 3f06f5a..b72f834 100644
 --- a/src/utils.py
 +++ b/src/utils.py
-@@ -11,7 +11,7 @@ FLARESOLVERR_VERSION = None
+@@ -12,7 +12,7 @@ CHROME_EXE_PATH = None
  CHROME_MAJOR_VERSION = None
  USER_AGENT = None
  XVFB_DISPLAY = None

--- a/post_install.sh
+++ b/post_install.sh
@@ -51,41 +51,5 @@ index ceff7ec..dd3aba5 100644
  def get_config_log_html() -> bool:
 EOF
 
-# -- Set up service
-
-cat > /usr/local/etc/rc.d/flaresolverr << EOF
-#
-# Author: C. R. Zamana (czamana at gmail dot com)
-#
-# PROVIDE: flaresolverr
-# REQUIRE: networking
-# KEYWORD:
-
-. /etc/rc.subr
-
-name="flaresolverr"
-rcvar="\${name}_enable"
-load_rc_config \${name}
-
-: \${flaresolverr_enable:="NO"}
-
-pidfile="/var/run/flaresolverr.pid"
-
-start_precmd="flaresolverr_precmd"
-
-PATH=\$PATH:/usr/local/bin
-
-flaresolverr_precmd() {
-        cd /usr/local/share/flaresolverr
-}
-
-command="/usr/sbin/daemon"
-command_args="-P \${pidfile} -S -T flaresolverr /usr/local/bin/python3.9 -u src/flaresolverr.py"
-
-run_rc_command "\$1"
-EOF
-
-chmod +x /usr/local/etc/rc.d/flaresolverr
-
 sysrc flaresolverr_enable=YES
 service flaresolverr start

--- a/post_install.sh
+++ b/post_install.sh
@@ -9,34 +9,8 @@ git checkout v3.2.1
 
 pip install -r requirements.txt
 
-patch -V none -p1 << EOF
-diff --git a/src/undetected_chromedriver/patcher.py b/src/undetected_chromedriver/patcher.py
-index 24da802..159ae8d 100644
---- a/src/undetected_chromedriver/patcher.py
-+++ b/src/undetected_chromedriver/patcher.py
-@@ -17,7 +17,7 @@ import zipfile
-
- logger = logging.getLogger(__name__)
-
--IS_POSIX = sys.platform.startswith(("darwin", "cygwin", "linux", "linux2"))
-+IS_POSIX = sys.platform.startswith(("darwin", "cygwin", "linux", "linux2", "freebsd"))
-
-
- class Patcher(object):
-diff --git a/src/utils.py b/src/utils.py
-index 3f06f5a..b72f834 100644
---- a/src/utils.py
-+++ b/src/utils.py
-@@ -12,7 +12,7 @@ CHROME_EXE_PATH = None
- CHROME_MAJOR_VERSION = None
- USER_AGENT = None
- XVFB_DISPLAY = None
--PATCHED_DRIVER_PATH = None
-+PATCHED_DRIVER_PATH = "/usr/local/bin/chromedriver"
-
-
- def get_config_log_html() -> bool:
-EOF
+sed -i -e 's/^\(IS_POSIX =.*\)))/\1, "freebsd"))/' src/undetected_chromedriver/patcher.py
+sed -i -e 's/^\(PATCHED_DRIVER_PATH =\).*/\1 "\/usr\/local\/bin\/chromedriver"/' src/utils.py
 
 sysrc flaresolverr_enable=YES
 service flaresolverr start

--- a/post_update.sh
+++ b/post_update.sh
@@ -5,32 +5,6 @@ git fetch --all
 VERSION=$(git tag --sort=v:refname | tail -1)
 git checkout "$VERSION"
 pip install -U -r requirements.txt
-patch -V none -p1 << EOF
-diff --git a/src/undetected_chromedriver/patcher.py b/src/undetected_chromedriver/patcher.py
-index c20ead8..4c410e4 100644
---- a/src/undetected_chromedriver/patcher.py
-+++ b/src/undetected_chromedriver/patcher.py
-@@ -18,7 +18,7 @@ import zipfile
-
- logger = logging.getLogger(__name__)
-
--IS_POSIX = sys.platform.startswith(("darwin", "cygwin", "linux", "linux2"))
-+IS_POSIX = sys.platform.startswith(("darwin", "cygwin", "linux", "linux2", "freebsd"))
-
-
- class Patcher(object):
-diff --git a/src/utils.py b/src/utils.py
-index ceff7ec..dd3aba5 100644
---- a/src/utils.py
-+++ b/src/utils.py
-@@ -11,7 +11,7 @@ FLARESOLVERR_VERSION = None
- CHROME_MAJOR_VERSION = None
- USER_AGENT = None
- XVFB_DISPLAY = None
--PATCHED_DRIVER_PATH = None
-+PATCHED_DRIVER_PATH = "/usr/local/bin/chromedriver"
-
-
- def get_config_log_html() -> bool:
-EOF
+sed -i '' -e 's/^\(IS_POSIX =.*\)))/\1, "freebsd"))/' src/undetected_chromedriver/patcher.py
+sed -i '' -e 's/^\(PATCHED_DRIVER_PATH =\).*/\1 "\/usr\/local\/bin\/chromedriver"/' src/utils.py
 service flaresolverr start

--- a/post_update.sh
+++ b/post_update.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+cd /usr/local/share/flaresolverr || exit
+git fetch --all
+VERSION=$(git tag --sort=v:refname | tail -1)
+git checkout "$VERSION"
+pip install -r requirements.txt
+service flaresolverr start

--- a/post_update.sh
+++ b/post_update.sh
@@ -4,5 +4,33 @@ cd /usr/local/share/flaresolverr || exit
 git fetch --all
 VERSION=$(git tag --sort=v:refname | tail -1)
 git checkout "$VERSION"
-pip install -r requirements.txt
+pip install -U -r requirements.txt
+patch -V none -p1 << EOF
+diff --git a/src/undetected_chromedriver/patcher.py b/src/undetected_chromedriver/patcher.py
+index c20ead8..4c410e4 100644
+--- a/src/undetected_chromedriver/patcher.py
++++ b/src/undetected_chromedriver/patcher.py
+@@ -18,7 +18,7 @@ import zipfile
+
+ logger = logging.getLogger(__name__)
+
+-IS_POSIX = sys.platform.startswith(("darwin", "cygwin", "linux", "linux2"))
++IS_POSIX = sys.platform.startswith(("darwin", "cygwin", "linux", "linux2", "freebsd"))
+
+
+ class Patcher(object):
+diff --git a/src/utils.py b/src/utils.py
+index ceff7ec..dd3aba5 100644
+--- a/src/utils.py
++++ b/src/utils.py
+@@ -11,7 +11,7 @@ FLARESOLVERR_VERSION = None
+ CHROME_MAJOR_VERSION = None
+ USER_AGENT = None
+ XVFB_DISPLAY = None
+-PATCHED_DRIVER_PATH = None
++PATCHED_DRIVER_PATH = "/usr/local/bin/chromedriver"
+
+
+ def get_config_log_html() -> bool:
+EOF
 service flaresolverr start

--- a/pre_update.sh
+++ b/pre_update.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+service flaresolverr stop
+cd /usr/local/share/flaresolverr || exit
+git reset --hard @

--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,3 @@
+{
+	"servicerestart":"service flaresolverr restart"
+}


### PR DESCRIPTION
Hi,
Here the PR related to #2 to update the `post_install.sh` script so it support the latest major release of FlareSolverr which now use python and target he current latest version `3.0.2`.